### PR TITLE
Safe batch transfer contract

### DIFF
--- a/contracts/interfaces/IBatchTransferNFT.sol
+++ b/contracts/interfaces/IBatchTransferNFT.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IBatchTransferNFT {
+    struct Transfer {
+        address nft;
+        address recipient;
+        uint256 tokenId;
+        uint256 amount;
+    }
+
+    function batchTransfer(Transfer[] calldata _transfers) external;
+}

--- a/contracts/interfaces/IPausableAdmin.sol
+++ b/contracts/interfaces/IPausableAdmin.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IPausableAdmin {
+    event PauseAdminAdded(address newAdmin);
+    event PauseAdminRemoved(address sender, address removedAdmin);
+    event PauseAdminRevoked(address revokedAdmin);
+
+    function getPauseAdminAt(uint256 _index) external view returns (address);
+
+    function getNumberOfPauseAdmin() external view returns (uint256);
+
+    function addPauseAdmin(address _newAdmin) external;
+
+    function removePauseAdmin(address _admin) external;
+
+    function revokePauseAdmin() external;
+}

--- a/contracts/interfaces/IPendingOwnable.sol
+++ b/contracts/interfaces/IPendingOwnable.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IPendingOwnable {
+    event PendingOwnerSet(address indexed pendingOwner);
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+
+    function owner() external view returns (address);
+
+    function pendingOwner() external view returns (address);
+
+    function setPendingOwner(address pendingOwner) external;
+
+    function revokePendingOwner() external;
+
+    function becomeOwner() external;
+
+    function renounceOwnership() external;
+}

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -32,8 +32,7 @@ contract BatchTransferNFT {
                     IERC721(_transfer.nft).safeTransferFrom(
                         msg.sender,
                         _transfer.recipient,
-                        _transfer.tokenId,
-                        ""
+                        _transfer.tokenId
                     );
                 } else {
                     IERC1155(_transfer.nft).safeTransferFrom(

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -13,22 +13,22 @@ contract BatchTransferNFT {
         address nft;
         address recipient;
         uint256 tokenId;
-        uint256 quantity;
+        uint256 amount;
     }
 
     /**
      * @notice Batch transfer different NFT in a single call
      * @param _transfers The list of transfer.
-     * The quantity defines the type of NFT:
-     *  - quantity = 0: ERC721
-     *  - quantity > 0: ERC1155
+     * The amount defines the type of NFT:
+     *  - amount = 0: ERC721
+     *  - amount > 0: ERC1155
      */
     function batchTransfer(Transfer[] calldata _transfers) external {
         uint256 _length = _transfers.length;
         unchecked {
             for (uint256 i; i < _length; ++i) {
                 Transfer memory _transfer = _transfers[i];
-                if (_transfer.quantity == 0) {
+                if (_transfer.amount == 0) {
                     IERC721(_transfer.nft).safeTransferFrom(
                         msg.sender,
                         _transfer.recipient,
@@ -40,7 +40,7 @@ contract BatchTransferNFT {
                         msg.sender,
                         _transfer.recipient,
                         _transfer.tokenId,
-                        _transfer.quantity,
+                        _transfer.amount,
                         ""
                     );
                 }

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -3,47 +3,88 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "./PausableAdmin.sol";
+import "../interfaces/IBatchTransferNFT.sol";
+
+error BatchTransferNFT__UnsupportedContract(address nft);
 
 /**
  * @title BatchTransferNFT
  * @notice Enables to batch transfer multiple NFTs in a single call to this contract
  */
-contract BatchTransferNFT {
-    struct Transfer {
-        address nft;
-        address recipient;
-        uint256 tokenId;
-        uint256 amount;
+contract BatchTransferNFT is PausableAdmin, IBatchTransferNFT {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        pure
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IBatchTransferNFT).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /**
      * @notice Batch transfer different NFT in a single call
+     * @dev The function can get paused
      * @param _transfers The list of transfer.
-     * The amount defines the type of NFT:
-     *  - amount = 0: ERC721
-     *  - amount > 0: ERC1155
+     * The different nft needs to support either the IERC721 or IERC1155 interface
      */
-    function batchTransfer(Transfer[] calldata _transfers) external {
+    function batchTransfer(Transfer[] calldata _transfers)
+        external
+        override
+        whenNotPaused
+    {
         uint256 _length = _transfers.length;
         unchecked {
             for (uint256 i; i < _length; ++i) {
                 Transfer memory _transfer = _transfers[i];
-                if (_transfer.amount == 0) {
+
+                if (_isERC721(_transfer.nft)) {
                     IERC721(_transfer.nft).safeTransferFrom(
-                        msg.sender,
+                        _msgSender(),
                         _transfer.recipient,
                         _transfer.tokenId
                     );
-                } else {
+                } else if (_isERC1155(_transfer.nft)) {
                     IERC1155(_transfer.nft).safeTransferFrom(
-                        msg.sender,
+                        _msgSender(),
                         _transfer.recipient,
                         _transfer.tokenId,
                         _transfer.amount,
                         ""
                     );
+                } else {
+                    revert BatchTransferNFT__UnsupportedContract(_transfer.nft);
                 }
             }
         }
+    }
+
+    /**
+     * @notice Internal view function to return whether the address supports IERC721
+     * @param nft The address of the nft
+     * @return Whether the interface is supported or not
+     */
+    function _isERC721(address nft) internal view returns (bool) {
+        return IERC165(nft).supportsInterface(type(IERC721).interfaceId);
+    }
+
+    /**
+     * @notice Internal view function to return whether the address supports IERC1155
+     * @param nft The address of the nft
+     * @return Whether the interface is supported or not
+     */
+    function _isERC1155(address nft) internal view returns (bool) {
+        return IERC165(nft).supportsInterface(type(IERC1155).interfaceId);
     }
 }

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+/**
+ * @title BatchTransferNFT
+ * @notice Enables to batch transfer multiple NFTs in a single call to this contract
+ */
+contract BatchTransferNFT {
+    struct Transfer {
+        address nft;
+        address recipient;
+        uint256 tokenId;
+        uint256 quantity;
+    }
+
+    /**
+     * @notice Batch transfer different NFT in a single call
+     * @param _transfers The list of transfer.
+     * The quantity defines the type of NFT:
+     *  - quantity = 0: ERC721
+     *  - quantity > 0: ERC1155
+     */
+    function batchTransfer(Transfer[] calldata _transfers) external {
+        uint256 _length = _transfers.length;
+        unchecked {
+            for (uint256 i; i < _length; ++i) {
+                Transfer memory _transfer = _transfers[i];
+                if (_transfer.quantity == 0) {
+                    IERC721(_transfer.nft).safeTransferFrom(
+                        msg.sender,
+                        _transfer.recipient,
+                        _transfer.tokenId,
+                        ""
+                    );
+                } else {
+                    IERC1155(_transfer.nft).safeTransferFrom(
+                        msg.sender,
+                        _transfer.recipient,
+                        _transfer.tokenId,
+                        _transfer.quantity,
+                        ""
+                    );
+                }
+            }
+        }
+    }
+}

--- a/contracts/utils/PausableAdmin.sol
+++ b/contracts/utils/PausableAdmin.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "./PendingOwnable.sol";
+import "../interfaces/IPausableAdmin.sol";
+
+error PausableAdmin__AlreadyPaused();
+error PausableAdmin__AlreadyUnpaused();
+error PausableAdmin__OnlyRenounceForSelf(address sender);
+error PausableAdmin__OnlyPauseAdmin(address sender);
+error PausableAdmin__AddressIsNotPauseAdmin(address sender);
+error PausableAdmin__AddressIsAlreadyPauseAdmin(address sender);
+
+contract PausableAdmin is PendingOwnable, Pausable, IPausableAdmin {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    EnumerableSet.AddressSet private _pauseAdmins;
+
+    modifier onlyPauseAdmin() {
+        if (!_pauseAdmins.contains(msg.sender))
+            revert PausableAdmin__OnlyPauseAdmin(msg.sender);
+        _;
+    }
+
+    constructor() {
+        _addPauseAdmin(msg.sender);
+    }
+
+    /**
+     * @notice View function to return the pause admin at index `_index`
+     * @param _index The index in the array
+     * @return The address of the admin at index `_index`
+     */
+    function getPauseAdminAt(uint256 _index)
+        external
+        view
+        override
+        returns (address)
+    {
+        return _pauseAdmins.at(_index);
+    }
+
+    /**
+     * @notice View function to return the number of pause admins
+     * @return The number of pause admins
+     */
+    function getNumberOfPauseAdmin() external view override returns (uint256) {
+        return _pauseAdmins.length();
+    }
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        pure
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IPausableAdmin).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice Function to add a pause admin
+     * @dev Only callable by the owner
+     * @param _newAdmin The address of the new admin to add
+     */
+    function addPauseAdmin(address _newAdmin) external override onlyOwner {
+        _addPauseAdmin(_newAdmin);
+    }
+
+    /**
+     * @notice Function to remove a pause admin
+     * @dev Only callable by the owner
+     * @param _admin The address of the admin to remove
+     */
+    function removePauseAdmin(address _admin) external override onlyOwner {
+        _removePauseAdmin(_admin);
+    }
+
+    /**
+     * @notice Function callable by any admin to revoke their role
+     * @dev Only callable by the admin himself
+     */
+    function revokePauseAdmin() external override {
+        _revokePauseAdmin(msg.sender);
+    }
+
+    /**
+     * @notice Function to pause the contract
+     * @dev Only callable by any pause admin
+     */
+    function pause() external onlyPauseAdmin {
+        if (paused()) revert PausableAdmin__AlreadyPaused();
+        _pause();
+    }
+
+    /**
+     * @notice Function to unpause the contract
+     * @dev Only callable by the owner
+     */
+    function unpause() external onlyOwner {
+        if (!paused()) revert PausableAdmin__AlreadyUnpaused();
+        _unpause();
+    }
+
+    /**
+     * @notice Internal function to add a pause admin
+     * @param _newAdmin The address of the new admin to add
+     */
+    function _addPauseAdmin(address _newAdmin) internal {
+        if (!_pauseAdmins.add(_newAdmin))
+            revert PausableAdmin__AddressIsAlreadyPauseAdmin(_newAdmin);
+        emit PauseAdminAdded(_newAdmin);
+    }
+
+    /**
+     * @notice Internal function to remove a pause admin
+     * @param _admin The address of the admin to remove
+     */
+    function _removePauseAdmin(address _admin) internal {
+        if (!_pauseAdmins.remove(_admin))
+            revert PausableAdmin__AddressIsNotPauseAdmin(_admin);
+        emit PauseAdminRemoved(msg.sender, _admin);
+    }
+
+    /**
+     * @notice Internal function to revoke the role of an admin
+     */
+    function _revokePauseAdmin(address _revokedAdmin) internal {
+        if (!_pauseAdmins.remove(_revokedAdmin))
+            revert PausableAdmin__AddressIsNotPauseAdmin(_revokedAdmin);
+        emit PauseAdminRevoked(_revokedAdmin);
+    }
+}

--- a/contracts/utils/PendingOwnable.sol
+++ b/contracts/utils/PendingOwnable.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../interfaces/IPendingOwnable.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+error PendingOwnable__NotOwner();
+error PendingOwnable__NotPendingOwner();
+error PendingOwnable__PendingOwnerAlreadySet();
+error PendingOwnable__NoPendingOwner();
+
+/**
+ * @title Pending Ownable
+ * @author Trader Joe
+ * @notice Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions. The ownership of this contract is transferred using the
+ * push and pull pattern, the current owner set a `pendingOwner` using
+ * {setPendingOwner} and that address can then call {becomeOwner} to become the
+ * owner of that contract. The main logic and comments comes from OpenZeppelin's
+ * Ownable contract.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {setPendingOwner} and {becomeOwner}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner
+ */
+contract PendingOwnable is IERC165, IPendingOwnable {
+    address private _owner;
+    address private _pendingOwner;
+
+    /**
+     * @notice Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        if (msg.sender != _owner) revert PendingOwnable__NotOwner();
+        _;
+    }
+
+    /**
+     * @notice Throws if called by any account other than the pending owner.
+     */
+    modifier onlyPendingOwner() {
+        if (msg.sender != _pendingOwner || msg.sender == address(0))
+            revert PendingOwnable__NotPendingOwner();
+        _;
+    }
+
+    /**
+     * @notice Initializes the contract setting the deployer as the initial owner
+     */
+    constructor() {
+        _transferOwnership(msg.sender);
+    }
+
+    /**
+     * @notice Returns the address of the current owner
+     * @return The address of the current owner
+     */
+    function owner() public view override returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @notice Returns the address of the current pending owner
+     * @return The address of the current pending owner
+     */
+    function pendingOwner() public view override returns (address) {
+        return _pendingOwner;
+    }
+
+    /**
+     * @notice Sets the pending owner address. This address will be able to become
+     * the owner of this contract by calling {becomeOwner}
+     */
+    function setPendingOwner(address pendingOwner_) public override onlyOwner {
+        if (_pendingOwner != address(0))
+            revert PendingOwnable__PendingOwnerAlreadySet();
+        _setPendingOwner(pendingOwner_);
+    }
+
+    /**
+     * @notice Revoke the pending owner address. This address will not be able to
+     * call {becomeOwner} to become the owner anymore.
+     * Can only be called by the owner
+     */
+    function revokePendingOwner() public override onlyOwner {
+        if (_pendingOwner == address(0))
+            revert PendingOwnable__NoPendingOwner();
+        _setPendingOwner(address(0));
+    }
+
+    /**
+     * @notice Transfers the ownership to the new owner (`pendingOwner).
+     * Can only be called by the pending owner
+     */
+    function becomeOwner() public override onlyPendingOwner {
+        _transferOwnership(msg.sender);
+    }
+
+    /**
+     * @notice Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public override onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        pure
+        virtual
+        returns (bool)
+    {
+        return
+            interfaceId == this.supportsInterface.selector ||
+            interfaceId == type(IPendingOwnable).interfaceId;
+    }
+
+    /**
+     * @notice Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     * @param _newOwner The address of the new owner
+     */
+    function _transferOwnership(address _newOwner) internal virtual {
+        address _oldOwner = _owner;
+        _owner = _newOwner;
+        _pendingOwner = address(0);
+        emit OwnershipTransferred(_oldOwner, _newOwner);
+    }
+
+    /**
+     * @notice Push the new owner, it needs to be pulled to be effective.
+     * Internal function without access restriction.
+     * @param pendingOwner_ The address of the new pending owner
+     */
+    function _setPendingOwner(address pendingOwner_) internal virtual {
+        _pendingOwner = pendingOwner_;
+        emit PendingOwnerSet(pendingOwner_);
+    }
+}

--- a/test/BatchTransferNFT.test.js
+++ b/test/BatchTransferNFT.test.js
@@ -1,0 +1,237 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+describe("BatchTransferNFT", function () {
+  before(async function () {
+    this.ERC721TokenCF = await ethers.getContractFactory("ERC721Token");
+    this.ERC1155TokenCF = await ethers.getContractFactory("ERC1155Token");
+    this.BatchTransferNFTCF = await ethers.getContractFactory(
+      "BatchTransferNFT"
+    );
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.erc721Token = await this.ERC721TokenCF.deploy();
+    this.erc1155Token = await this.ERC1155TokenCF.deploy();
+    this.batchTransferNFT = await this.BatchTransferNFTCF.deploy();
+
+    // Mint ERC721 tokens
+    for (let i = 0; i < 3; ++i) await this.erc721Token.mint(this.alice.address);
+
+    // Mint ERC1155 tokens
+    this.erc1155Tokens = [
+      { id: 1, amount: 10 },
+      { id: 2, amount: 5 },
+    ];
+    await Promise.all(
+      this.erc1155Tokens.map((token) =>
+        this.erc1155Token.mint(this.alice.address, token.id, token.amount, [])
+      )
+    );
+  });
+  it("Should revert if the contract isn't approved", async function () {
+    const recipient = this.bob.address;
+
+    const transfersERC721 = [
+      {
+        nft: this.erc721Token.address,
+        recipient: recipient,
+        tokenId: 1,
+        quantity: 0,
+      },
+    ];
+
+    await expect(
+      this.batchTransferNFT.connect(this.alice).batchTransfer(transfersERC721)
+    ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+
+    const token = this.erc1155Tokens[0];
+
+    const transfersERC1155 = [
+      {
+        nft: this.erc1155Token.address,
+        recipient: recipient,
+        tokenId: token.id,
+        quantity: token.amount,
+      },
+    ];
+
+    await expect(
+      this.batchTransferNFT.connect(this.alice).batchTransfer(transfersERC1155)
+    ).to.be.revertedWith("ERC1155: caller is not owner nor approved");
+  });
+
+  it("Should revert if another user tries to transfer NFTs even if the user has approved the contract", async function () {
+    const tokenIds = [1, 2];
+    const recipient = this.bob.address;
+
+    // Alice must approve the batchTransferNFT as operator for both NFTs
+    await this.erc1155Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+    await this.erc721Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+
+    const transfersERC721 = [
+      {
+        nft: this.erc721Token.address,
+        recipient: recipient,
+        tokenId: 1,
+        quantity: 0,
+      },
+    ];
+
+    await expect(
+      this.batchTransferNFT.connect(this.bob).batchTransfer(transfersERC721)
+    ).to.be.revertedWith("ERC721: transfer from incorrect owner");
+
+    const token = this.erc1155Tokens[0];
+
+    const transfersERC1155 = [
+      {
+        nft: this.erc1155Token.address,
+        recipient: recipient,
+        tokenId: token.id,
+        quantity: token.amount,
+      },
+    ];
+
+    await expect(
+      this.batchTransferNFT.connect(this.bob).batchTransfer(transfersERC1155)
+    ).to.be.revertedWith("ERC1155: caller is not owner nor approved");
+  });
+
+  it("Should allow to transfer multiple ERC721 tokens in a single call", async function () {
+    const tokenIds = [1, 2];
+    const sender = this.alice.address;
+    const recipient = this.bob.address;
+
+    // Check that Alice has the tokens
+    expect(await this.erc721Token.ownerOf(1)).to.be.equal(sender);
+    expect(await this.erc721Token.ownerOf(2)).to.be.equal(sender);
+
+    // Alice must approve the batchTransferNFT contract as operator
+    await this.erc721Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+
+    const transfers = tokenIds.map((tokenId) => {
+      return {
+        nft: this.erc721Token.address,
+        recipient: recipient,
+        tokenId: tokenId,
+        quantity: 0,
+      };
+    });
+
+    // Transfer NFTs
+    await this.batchTransferNFT.connect(this.alice).batchTransfer(transfers);
+
+    // Check that Bob received the tokens
+    expect(await this.erc721Token.ownerOf(1)).to.be.equal(recipient);
+    expect(await this.erc721Token.ownerOf(2)).to.be.equal(recipient);
+  });
+
+  it("Should allow to transfer multiple ERC1155 tokens in a single call", async function () {
+    const sender = this.alice.address;
+    const recipient = this.bob.address;
+
+    // Check that Alice has the tokens
+    let balances = await Promise.all(
+      this.erc1155Tokens.map((token) =>
+        this.erc1155Token.balanceOf(sender, token.id)
+      )
+    );
+    expect(balances.map((balance) => balance.toNumber())).to.eql(
+      this.erc1155Tokens.map((token) => token.amount)
+    );
+
+    // Alice must approve the batchTransferNFT as operator
+    await this.erc1155Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+
+    const transfers = this.erc1155Tokens.map((token) => {
+      return {
+        nft: this.erc1155Token.address,
+        recipient: recipient,
+        tokenId: token.id,
+        quantity: token.amount,
+      };
+    });
+
+    // Transfer NFTs
+    await this.batchTransferNFT.connect(this.alice).batchTransfer(transfers);
+
+    // Check that Bob received the tokens
+    balances = await Promise.all(
+      this.erc1155Tokens.map((token) =>
+        this.erc1155Token.balanceOf(recipient, token.id)
+      )
+    );
+    expect(balances.map((balance) => balance.toNumber())).to.eql(
+      this.erc1155Tokens.map((token) => token.amount)
+    );
+  });
+
+  it("Should allow to transfer multiple ERC721 and ERC1155 tokens in a single call", async function () {
+    const tokenIds = [1, 2];
+    const recipient = this.bob.address;
+
+    // Alice must approve the batchTransferNFT as operator for both NFTs
+    await this.erc1155Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+    await this.erc721Token
+      .connect(this.alice)
+      .setApprovalForAll(this.batchTransferNFT.address, true);
+
+    const transfersERC1155 = this.erc1155Tokens.map((token) => {
+      return {
+        nft: this.erc1155Token.address,
+        recipient: recipient,
+        tokenId: token.id,
+        quantity: token.amount,
+      };
+    });
+    const transfersERC721 = tokenIds.map((tokenId) => {
+      return {
+        nft: this.erc721Token.address,
+        recipient: recipient,
+        tokenId: tokenId,
+        quantity: 0,
+      };
+    });
+
+    const transfers = transfersERC1155.concat(transfersERC721);
+
+    // Transfer NFTs
+    await this.batchTransferNFT.connect(this.alice).batchTransfer(transfers);
+
+    // Check that Bob received the tokens
+    expect(await this.erc721Token.ownerOf(1)).to.be.equal(recipient);
+    expect(await this.erc721Token.ownerOf(2)).to.be.equal(recipient);
+    balances = await Promise.all(
+      this.erc1155Tokens.map((token) =>
+        this.erc1155Token.balanceOf(recipient, token.id)
+      )
+    );
+    expect(balances.map((balance) => balance.toNumber())).to.eql(
+      this.erc1155Tokens.map((token) => token.amount)
+    );
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});

--- a/test/BatchTransferNFT.test.js
+++ b/test/BatchTransferNFT.test.js
@@ -43,7 +43,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc721Token.address,
         recipient: recipient,
         tokenId: 1,
-        quantity: 0,
+        amount: 0,
       },
     ];
 
@@ -58,7 +58,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc1155Token.address,
         recipient: recipient,
         tokenId: token.id,
-        quantity: token.amount,
+        amount: token.amount,
       },
     ];
 
@@ -84,7 +84,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc721Token.address,
         recipient: recipient,
         tokenId: 1,
-        quantity: 0,
+        amount: 0,
       },
     ];
 
@@ -99,7 +99,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc1155Token.address,
         recipient: recipient,
         tokenId: token.id,
-        quantity: token.amount,
+        amount: token.amount,
       },
     ];
 
@@ -127,7 +127,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc721Token.address,
         recipient: recipient,
         tokenId: tokenId,
-        quantity: 0,
+        amount: 0,
       };
     });
 
@@ -163,7 +163,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc1155Token.address,
         recipient: recipient,
         tokenId: token.id,
-        quantity: token.amount,
+        amount: token.amount,
       };
     });
 
@@ -198,7 +198,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc1155Token.address,
         recipient: recipient,
         tokenId: token.id,
-        quantity: token.amount,
+        amount: token.amount,
       };
     });
     const transfersERC721 = tokenIds.map((tokenId) => {
@@ -206,7 +206,7 @@ describe("BatchTransferNFT", function () {
         nft: this.erc721Token.address,
         recipient: recipient,
         tokenId: tokenId,
-        quantity: 0,
+        amount: 0,
       };
     });
 

--- a/test/PausableAdmin.test.js
+++ b/test/PausableAdmin.test.js
@@ -1,0 +1,92 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+describe("BatchTransferNFT", function () {
+  before(async function () {
+    this.pausableAdminCF = await ethers.getContractFactory("PausableAdmin");
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.pausableAdmin = await this.pausableAdminCF.deploy();
+  });
+
+  it("Should allow owner to pause and unpause the contract", async function () {
+    await this.pausableAdmin.pause();
+
+    expect(await this.pausableAdmin.paused()).to.be.equal(true);
+
+    await expect(this.pausableAdmin.pause()).to.be.revertedWith(
+      "PausableAdmin__AlreadyPaused"
+    );
+
+    await this.pausableAdmin.unpause();
+
+    expect(await this.pausableAdmin.paused()).to.be.equal(false);
+
+    await expect(this.pausableAdmin.unpause()).to.be.revertedWith(
+      "PausableAdmin__AlreadyUnpaused"
+    );
+  });
+
+  it("Should revert if a non owner tries to pause or unpause the contract", async function () {
+    await expect(
+      this.pausableAdmin.connect(this.alice).pause()
+    ).to.be.revertedWith("PausableAdmin__OnlyPauseAdmin");
+    await expect(
+      this.pausableAdmin.connect(this.alice).unpause()
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+  });
+
+  it("Should allow a new admin to pause but revert to unpause the contract", async function () {
+    await this.pausableAdmin
+      .connect(this.dev)
+      .addPauseAdmin(this.alice.address);
+
+    await this.pausableAdmin.connect(this.alice).pause();
+
+    expect(await this.pausableAdmin.paused()).to.be.equal(true);
+
+    await expect(
+      this.pausableAdmin.connect(this.alice).unpause()
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await this.pausableAdmin.revokePauseAdmin();
+
+    await expect(this.pausableAdmin.revokePauseAdmin()).to.be.revertedWith(
+      "PausableAdmin__AddressIsNotPauseAdmin"
+    );
+  });
+
+  it("Should only allow admin to add or remove admin", async function () {
+    this.pausableAdmin.connect(this.dev).addPauseAdmin(this.alice.address);
+
+    await expect(
+      this.pausableAdmin.connect(this.bob).addPauseAdmin(this.bob.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pausableAdmin.connect(this.alice).addPauseAdmin(this.bob.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pausableAdmin.connect(this.bob).removePauseAdmin(this.dev.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pausableAdmin.connect(this.alice).removePauseAdmin(this.dev.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});

--- a/test/PendingOwnable.test.js
+++ b/test/PendingOwnable.test.js
@@ -1,0 +1,81 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+describe("BatchTransferNFT", function () {
+  before(async function () {
+    this.pendingOwnableCF = await ethers.getContractFactory("PendingOwnable");
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.pendingOwnable = await this.pendingOwnableCF.deploy();
+  });
+
+  it("Should revert if a non owner tries to use owner function", async function () {
+    await expect(
+      this.pendingOwnable
+        .connect(this.alice)
+        .setPendingOwner(this.alice.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pendingOwnable.connect(this.alice).revokePendingOwner()
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pendingOwnable.connect(this.alice).becomeOwner()
+    ).to.be.revertedWith("PendingOwnable__NotPendingOwner");
+
+    await expect(
+      this.pendingOwnable.connect(this.alice).renounceOwnership()
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+  });
+
+  it("Should allow owner to call ownable function", async function () {
+    await expect(
+      this.pendingOwnable.connect(this.dev).revokePendingOwner()
+    ).to.be.revertedWith("PendingOwnable__NoPendingOwner");
+
+    await this.pendingOwnable
+      .connect(this.dev)
+      .setPendingOwner(this.alice.address);
+
+    await expect(
+      this.pendingOwnable.connect(this.dev).setPendingOwner(this.alice.address)
+    ).to.be.revertedWith("PendingOwnable__PendingOwnerAlreadySet");
+
+    await this.pendingOwnable.connect(this.dev).revokePendingOwner();
+
+    await expect(
+      this.pendingOwnable.connect(this.dev).revokePendingOwner()
+    ).to.be.revertedWith("PendingOwnable__NoPendingOwner");
+  });
+
+  it("Should allow the pendingOwner to become the owner and revert on the previous owner", async function () {
+    await this.pendingOwnable
+      .connect(this.dev)
+      .setPendingOwner(this.alice.address);
+
+    await this.pendingOwnable.connect(this.alice).becomeOwner();
+
+    await expect(
+      this.pendingOwnable.connect(this.dev).setPendingOwner(this.alice.address)
+    ).to.be.revertedWith("PendingOwnable__NotOwner");
+
+    await expect(
+      this.pendingOwnable.connect(this.alice).becomeOwner()
+    ).to.be.revertedWith("PendingOwnable__NotPendingOwner");
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});


### PR DESCRIPTION
Implementation of the batch transfer contract, that only allows sending NFT owned by `msg.sender`.
Also tested the revert scenario, `Should revert if another user tries to transfer NFTs even if the user has approved the contract` asserts that the previous exploit can't happen.