### PR TITLE
Ignore expired maker asks in batch buy transactions

### DIFF
--- a/contracts/JoepegExchange.sol
+++ b/contracts/JoepegExchange.sol
@@ -636,8 +636,8 @@ contract JoepegExchange is
         }
 
         // Return remaining AVAX (if any)
-        uint256 remainingAVAX = msg.value - totalCost;
-        if (remainingAVAX > 0) {
+        if (msg.value > totalCost) {
+            uint256 remainingAVAX = msg.value - totalCost;
             (bool sent, ) = msg.sender.call{value: remainingAVAX}("");
             require(sent, "Batch Buy: Failed to return remaining AVAX");
         }

--- a/contracts/JoepegExchange.sol
+++ b/contracts/JoepegExchange.sol
@@ -228,7 +228,7 @@ contract JoepegExchange is
         _validateMakerAskAndTakerBid(takerBid, makerAsk);
 
         // Skip call when maker ask has expired
-        if (!_validateMakerOrder(makerAsk)) {
+        if (!_checkMakerOrderNotExpired(makerAsk)) {
             return;
         }
 
@@ -607,7 +607,7 @@ contract JoepegExchange is
         // Calculate the total cost of all valid orders
         uint256 totalCost;
         for (uint256 i; i < trades.length; ++i) {
-            if (_validateMakerOrder(trades[i].makerAsk)) {
+            if (_checkMakerOrderNotExpired(trades[i].makerAsk)) {
                 totalCost += trades[i].takerBid.price;
             }
         }
@@ -857,7 +857,11 @@ contract JoepegExchange is
         return (protocolFee * _amount) / PERCENTAGE_PRECISION;
     }
 
-    function _validateMakerOrder(OrderTypes.MakerOrder calldata makerOrder)
+    /**
+      * @notice Check whether the maker order has expired or not
+      * @param makerOrder maker order  
+     */
+    function _checkMakerOrderNotExpired(OrderTypes.MakerOrder calldata makerOrder)
         internal
         view
         returns (bool)
@@ -879,7 +883,7 @@ contract JoepegExchange is
     ) internal view {
         // Verify whether order nonce has expired
         require(
-            _validateMakerOrder(makerOrder),
+            _checkMakerOrderNotExpired(makerOrder),
             "Order: Matching order expired"
         );
 

--- a/contracts/interfaces/IJoepegExchange.sol
+++ b/contracts/interfaces/IJoepegExchange.sol
@@ -16,7 +16,7 @@ interface IJoepegBuyBatcher {
 
     function batchBuyWithAVAXAndWAVAXIgnoringExpiredAsks(
         Trade[] calldata trades
-    ) external payable;
+    ) external payable returns (bool[] memory transferStatus);
 }
 
 interface IJoepegExchange is IJoepegBuyBatcher {

--- a/contracts/interfaces/IJoepegExchange.sol
+++ b/contracts/interfaces/IJoepegExchange.sol
@@ -13,6 +13,10 @@ interface IJoepegBuyBatcher {
     }
 
     function batchBuyWithAVAXAndWAVAX(Trade[] calldata trades) external payable;
+
+    function batchBuyWithAVAXAndWAVAXIgnoringExpiredAsks(
+        Trade[] calldata trades
+    ) external payable;
 }
 
 interface IJoepegExchange is IJoepegBuyBatcher {

--- a/test/JoepegExchange.test.js
+++ b/test/JoepegExchange.test.js
@@ -968,7 +968,6 @@ describe("JoepegExchange", function () {
           const bobWavaxBalanceBefore = await this.wavax.balanceOf(
             this.bob.address
           );
-          expect(bobWavaxBalanceBefore).to.be.eq(total);
 
           // Batch buy
           await this.exchange
@@ -1014,7 +1013,6 @@ describe("JoepegExchange", function () {
           const bobWavaxBalanceBefore = await this.wavax.balanceOf(
             this.bob.address
           );
-          expect(bobWavaxBalanceBefore).to.be.eq(depositAmount);
 
           // Batch buy: Bob wants to pay with 1.5 WAVAX and 1.5 AVAX
           await this.exchange


### PR DESCRIPTION
### Changes
This PR adds a method `batchBuyWithAVAXAndWAVAXIgnoringExpiredAsks` to batch buy NFTs while ignoring expired maker asks.

There are two differences with `batchBuyWithAVAXAndWAVAX` : 
- Before matching a maker ask with a taker bid, we verify that the maker ask is valid and when it's invalid, we ignore the trade ;
- We transfer WAVAX to pay for the valid orders only. If the caller sent more AVAX than necessary, he's refunded.

### Context

This is useful for highly anticipated launches (like peon) where many people try to sweep the floor / buy the same item at the same time. 

For example, Bob wants to buy peon A, B and C; he submits a transaction but Carol bought peon B right before. Bob still wants to get peon A and C (right now, the whole transaction would revert).

On the frontend, we'll probably have a toggle in the shopping cart to enable/disable this option which means using `batchBuyWithAVAXAndWAVAXIgnoringExpiredAsks` or `batchBuyWithAVAXAndWAVAX` accordingly.

