### PR TITLE
SafePauble and SafeEnumerableAccess

### DIFF
--- a/contracts/interfaces/ISafePausable.sol
+++ b/contracts/interfaces/ISafePausable.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/IAccessControlEnumerable.sol";
+
+import "../interfaces/IPendingOwnable.sol";
+
+interface ISafePausable is IAccessControlEnumerable, IPendingOwnable {
+    function PAUSER_ROLE() external pure returns (bytes32);
+
+    function UNPAUSER_ROLE() external pure returns (bytes32);
+
+    function PAUSER_ADMIN_ROLE() external pure returns (bytes32);
+
+    function UNPAUSER_ADMIN_ROLE() external pure returns (bytes32);
+
+    function pause() external;
+
+    function unpause() external;
+}

--- a/contracts/interfaces/ISafePausableUpgradeable.sol
+++ b/contracts/interfaces/ISafePausableUpgradeable.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/IAccessControlEnumerableUpgradeable.sol";
+
+import "../interfaces/IPendingOwnableUpgradeable.sol";
+
+interface ISafePausableUpgradeable is
+    IAccessControlEnumerableUpgradeable,
+    IPendingOwnableUpgradeable
+{
+    function PAUSER_ROLE() external pure returns (bytes32);
+
+    function UNPAUSER_ROLE() external pure returns (bytes32);
+
+    function PAUSER_ADMIN_ROLE() external pure returns (bytes32);
+
+    function UNPAUSER_ADMIN_ROLE() external pure returns (bytes32);
+
+    function pause() external;
+
+    function unpause() external;
+}

--- a/contracts/mocks/MockSafeAccessControlEnumerable.sol
+++ b/contracts/mocks/MockSafeAccessControlEnumerable.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/SafeAccessControlEnumerable.sol";
+
+/// @title Mock contract using `SafeAccessControlEnumerable`
+/// @author Trader Joe
+contract MockSafeAccessControlEnumerable is SafeAccessControlEnumerable {
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyOwner {
+        _setRoleAdmin(role, adminRole);
+    }
+}

--- a/contracts/mocks/MockSafeAccessControlEnumerableUpgradeable.sol
+++ b/contracts/mocks/MockSafeAccessControlEnumerableUpgradeable.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/SafeAccessControlEnumerableUpgradeable.sol";
+
+/// @title Mock contract using `SafeAccessControlEnumerableUpgradeable`
+/// @author Trader Joe
+contract MockSafeAccessControlEnumerableUpgradeable is
+    SafeAccessControlEnumerableUpgradeable
+{
+    function initialize() external initializer {
+        __SafeAccessControlEnumerable_init();
+    }
+
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyOwner {
+        _setRoleAdmin(role, adminRole);
+    }
+}

--- a/contracts/mocks/MockSafePausable.sol
+++ b/contracts/mocks/MockSafePausable.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/SafePausable.sol";
+
+/// @title Mock contract using `SafePausable`
+/// @author Trader Joe
+contract MockSafePausable is SafePausable {
+    uint256 shh;
+
+    function pausableFunction() external whenNotPaused {
+        shh = shh;
+    }
+
+    function doSomething() external {
+        shh = shh;
+    }
+}

--- a/contracts/mocks/MockSafePausableUpgradeable.sol
+++ b/contracts/mocks/MockSafePausableUpgradeable.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/SafePausableUpgradeable.sol";
+
+/// @title Mock contract using `SafePausableUpgradeable`
+/// @author Trader Joe
+contract MockSafePausableUpgradeable is SafePausableUpgradeable {
+    uint256 shh;
+
+    function initialize() external initializer {
+        __SafePausable_init();
+    }
+
+    function pausableFunction() external whenNotPaused {
+        shh = shh;
+    }
+
+    function doSomething() external {
+        shh = shh;
+    }
+}

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -12,10 +12,7 @@ error BatchTransferNFT__UnsupportedContract(address nft);
  * @title BatchTransferNFT
  * @notice Enables to batch transfer multiple NFTs in a single call to this contract
  */
-contract BatchTransferNFT is
-    SafePausableAccessControlEnumerable,
-    IBatchTransferNFT
-{
+contract BatchTransferNFT is SafePausable, IBatchTransferNFT {
     /**
      * @dev Returns true if this contract implements the interface defined by
      * `interfaceId`. See the corresponding

--- a/contracts/utils/BatchTransferNFT.sol
+++ b/contracts/utils/BatchTransferNFT.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "./PausableAdmin.sol";
+import "./SafePausable.sol";
 import "../interfaces/IBatchTransferNFT.sol";
 
 error BatchTransferNFT__UnsupportedContract(address nft);
@@ -12,7 +12,10 @@ error BatchTransferNFT__UnsupportedContract(address nft);
  * @title BatchTransferNFT
  * @notice Enables to batch transfer multiple NFTs in a single call to this contract
  */
-contract BatchTransferNFT is PausableAdmin, IBatchTransferNFT {
+contract BatchTransferNFT is
+    SafePausableAccessControlEnumerable,
+    IBatchTransferNFT
+{
     /**
      * @dev Returns true if this contract implements the interface defined by
      * `interfaceId`. See the corresponding
@@ -23,7 +26,7 @@ contract BatchTransferNFT is PausableAdmin, IBatchTransferNFT {
      */
     function supportsInterface(bytes4 interfaceId)
         public
-        pure
+        view
         virtual
         override
         returns (bool)

--- a/contracts/utils/PausableAdmin.sol
+++ b/contracts/utils/PausableAdmin.sol
@@ -64,7 +64,7 @@ contract PausableAdmin is PendingOwnable, Pausable, IPausableAdmin {
      */
     function supportsInterface(bytes4 interfaceId)
         public
-        pure
+        view
         virtual
         override
         returns (bool)

--- a/contracts/utils/PendingOwnable.sol
+++ b/contracts/utils/PendingOwnable.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import "../interfaces/IPendingOwnable.sol";
 import "./PendingOwnableErrors.sol";
@@ -25,7 +25,7 @@ import "./PendingOwnableErrors.sol";
  * `onlyOwner`, which can be applied to your functions to restrict their use to
  * the owner
  */
-contract PendingOwnable is IERC165, IPendingOwnable {
+abstract contract PendingOwnable is ERC165, IPendingOwnable {
     address private _owner;
     address private _pendingOwner;
 
@@ -124,13 +124,14 @@ contract PendingOwnable is IERC165, IPendingOwnable {
      */
     function supportsInterface(bytes4 interfaceId)
         public
-        pure
+        view
         virtual
+        override
         returns (bool)
     {
         return
-            interfaceId == type(IERC165).interfaceId ||
-            interfaceId == type(IPendingOwnable).interfaceId;
+            interfaceId == type(IPendingOwnable).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /**

--- a/contracts/utils/SafeAccessControlEnumerable.sol
+++ b/contracts/utils/SafeAccessControlEnumerable.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+
+import "./PendingOwnable.sol";
+
+error SafePausableAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
+    bytes32 role,
+    address sender
+);
+
+abstract contract SafeAccessControlEnumerable is
+    PendingOwnable,
+    AccessControlEnumerable,
+    Pausable
+{
+    /**
+     * @dev Modifier that checks that the role is not the `DEFAULT_ADMIN_ROLE`
+     */
+    modifier RoleIsNotDefaultAdmin(bytes32 role) {
+        if (role == DEFAULT_ADMIN_ROLE) revert();
+        _;
+    }
+
+    /**
+     * @dev Modifier that checks that an account is the `owner` or has a specific role
+     */
+    modifier onlyOwnerOrRole(bytes32 role) {
+        if (msg.sender != owner() || !hasRole(role, msg.sender))
+            revert SafePausableAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
+                role,
+                msg.sender
+            );
+        _;
+    }
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(PendingOwnable, AccessControlEnumerable)
+        returns (bool)
+    {
+        return
+            PendingOwnable.supportsInterface(interfaceId) ||
+            AccessControl.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice Grants `role` to `account`.
+     * @dev If `account` had not been already granted `role`, emits a {RoleGranted} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be the `owner` or have ``role``'s admin role.
+     * - the role granted can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to grant
+     * @param account The address of the account
+     */
+    function grantRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        RoleIsNotDefaultAdmin(role)
+        onlyOwnerOrRole(getRoleAdmin(role))
+    {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @notice Revokes `role` from `account`.
+     * @dev If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be the `owner` or have ``role``'s admin role.
+     * - the role revoked can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to revoke
+     * @param account The address of the account
+     */
+    function revokeRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        RoleIsNotDefaultAdmin(role)
+        onlyOwnerOrRole(getRoleAdmin(role))
+    {
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @notice Revokes `role` from the calling account.
+     *
+     * @dev Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been revoked `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     * - the role renounced can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to renounce
+     * @param account The address of the account
+     */
+    function renounceRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        RoleIsNotDefaultAdmin(role)
+    {
+        super.revokeRole(role, account);
+    }
+
+    /**
+     * @notice Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     * @dev This also transfer the `DEFAULT_ADMIN` role to the new owner
+     * @param _newOwner The address of the new owner
+     */
+    function _transferOwnership(address _newOwner) internal virtual override {
+        _revokeRole(DEFAULT_ADMIN_ROLE, owner());
+        if (_newOwner != address(0)) _grantRole(DEFAULT_ADMIN_ROLE, _newOwner);
+
+        super._transferOwnership(_newOwner);
+    }
+}

--- a/contracts/utils/SafeAccessControlEnumerable.sol
+++ b/contracts/utils/SafeAccessControlEnumerable.sol
@@ -30,7 +30,7 @@ abstract contract SafeAccessControlEnumerable is
      * @dev Modifier that checks that an account is the `owner` or has a specific role
      */
     modifier onlyOwnerOrRole(bytes32 role) {
-        if (msg.sender != owner() || !hasRole(role, msg.sender))
+        if (msg.sender != owner() && !hasRole(role, msg.sender))
             revert SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
                 role,
                 msg.sender

--- a/contracts/utils/SafeAccessControlEnumerable.sol
+++ b/contracts/utils/SafeAccessControlEnumerable.sol
@@ -126,7 +126,7 @@ abstract contract SafeAccessControlEnumerable is
         override
         roleIsNotDefaultAdmin(role)
     {
-        super.revokeRole(role, account);
+        super.renounceRole(role, account);
     }
 
     /**

--- a/contracts/utils/SafeAccessControlEnumerable.sol
+++ b/contracts/utils/SafeAccessControlEnumerable.sol
@@ -3,25 +3,26 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "./PendingOwnable.sol";
 
-error SafePausableAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
+error SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
     bytes32 role,
     address sender
 );
 
+error SafeAccessControlEnumerable__RoleIsDefaultAdmin();
+
 abstract contract SafeAccessControlEnumerable is
     PendingOwnable,
-    AccessControlEnumerable,
-    Pausable
+    AccessControlEnumerable
 {
     /**
      * @dev Modifier that checks that the role is not the `DEFAULT_ADMIN_ROLE`
      */
-    modifier RoleIsNotDefaultAdmin(bytes32 role) {
-        if (role == DEFAULT_ADMIN_ROLE) revert();
+    modifier roleIsNotDefaultAdmin(bytes32 role) {
+        if (role == DEFAULT_ADMIN_ROLE)
+            revert SafeAccessControlEnumerable__RoleIsDefaultAdmin();
         _;
     }
 
@@ -30,7 +31,7 @@ abstract contract SafeAccessControlEnumerable is
      */
     modifier onlyOwnerOrRole(bytes32 role) {
         if (msg.sender != owner() || !hasRole(role, msg.sender))
-            revert SafePausableAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
+            revert SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner(
                 role,
                 msg.sender
             );
@@ -54,7 +55,7 @@ abstract contract SafeAccessControlEnumerable is
     {
         return
             PendingOwnable.supportsInterface(interfaceId) ||
-            AccessControl.supportsInterface(interfaceId);
+            AccessControlEnumerable.supportsInterface(interfaceId);
     }
 
     /**
@@ -73,7 +74,7 @@ abstract contract SafeAccessControlEnumerable is
         public
         virtual
         override
-        RoleIsNotDefaultAdmin(role)
+        roleIsNotDefaultAdmin(role)
         onlyOwnerOrRole(getRoleAdmin(role))
     {
         _grantRole(role, account);
@@ -95,7 +96,7 @@ abstract contract SafeAccessControlEnumerable is
         public
         virtual
         override
-        RoleIsNotDefaultAdmin(role)
+        roleIsNotDefaultAdmin(role)
         onlyOwnerOrRole(getRoleAdmin(role))
     {
         _revokeRole(role, account);
@@ -123,7 +124,7 @@ abstract contract SafeAccessControlEnumerable is
         public
         virtual
         override
-        RoleIsNotDefaultAdmin(role)
+        roleIsNotDefaultAdmin(role)
     {
         super.revokeRole(role, account);
     }

--- a/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
+++ b/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
@@ -138,7 +138,7 @@ abstract contract SafeAccessControlEnumerableUpgradeable is
         override
         roleIsNotDefaultAdmin(role)
     {
-        super.revokeRole(role, account);
+        super.renounceRole(role, account);
     }
 
     /**

--- a/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
+++ b/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
+
+import "./PendingOwnableUpgradeable.sol";
+
+error SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner(
+    bytes32 role,
+    address sender
+);
+
+error SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin();
+
+abstract contract SafeAccessControlEnumerableUpgradeable is
+    PendingOwnableUpgradeable,
+    AccessControlEnumerableUpgradeable
+{
+    /**
+     * @dev Modifier that checks that the role is not the `DEFAULT_ADMIN_ROLE`
+     */
+    modifier roleIsNotDefaultAdmin(bytes32 role) {
+        if (role == DEFAULT_ADMIN_ROLE)
+            revert SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin();
+        _;
+    }
+
+    /**
+     * @dev Modifier that checks that an account is the `owner` or has a specific role
+     */
+    modifier onlyOwnerOrRole(bytes32 role) {
+        if (msg.sender != owner() || !hasRole(role, msg.sender))
+            revert SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner(
+                role,
+                msg.sender
+            );
+        _;
+    }
+
+    function __SafeAccessControlEnumerable_init() internal onlyInitializing {
+        __PendingOwnable_init();
+        __SafeAccessControlEnumerable_init_unchained();
+    }
+
+    function __SafeAccessControlEnumerable_init_unchained()
+        internal
+        onlyInitializing
+    {}
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(PendingOwnableUpgradeable, AccessControlEnumerableUpgradeable)
+        returns (bool)
+    {
+        return
+            PendingOwnableUpgradeable.supportsInterface(interfaceId) ||
+            AccessControlEnumerableUpgradeable.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice Grants `role` to `account`.
+     * @dev If `account` had not been already granted `role`, emits a {RoleGranted} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be the `owner` or have ``role``'s admin role.
+     * - the role granted can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to grant
+     * @param account The address of the account
+     */
+    function grantRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        roleIsNotDefaultAdmin(role)
+        onlyOwnerOrRole(getRoleAdmin(role))
+    {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @notice Revokes `role` from `account`.
+     * @dev If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be the `owner` or have ``role``'s admin role.
+     * - the role revoked can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to revoke
+     * @param account The address of the account
+     */
+    function revokeRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        roleIsNotDefaultAdmin(role)
+        onlyOwnerOrRole(getRoleAdmin(role))
+    {
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @notice Revokes `role` from the calling account.
+     *
+     * @dev Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been revoked `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     * - the role renounced can't be `DEFAULT_ADMIN`
+     *
+     * @param role The role to renounce
+     * @param account The address of the account
+     */
+    function renounceRole(bytes32 role, address account)
+        public
+        virtual
+        override
+        roleIsNotDefaultAdmin(role)
+    {
+        super.revokeRole(role, account);
+    }
+
+    /**
+     * @notice Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     * @dev This also transfer the `DEFAULT_ADMIN` role to the new owner
+     * @param _newOwner The address of the new owner
+     */
+    function _transferOwnership(address _newOwner) internal virtual override {
+        _revokeRole(DEFAULT_ADMIN_ROLE, owner());
+        if (_newOwner != address(0)) _grantRole(DEFAULT_ADMIN_ROLE, _newOwner);
+
+        super._transferOwnership(_newOwner);
+    }
+}

--- a/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
+++ b/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
@@ -30,7 +30,7 @@ abstract contract SafeAccessControlEnumerableUpgradeable is
      * @dev Modifier that checks that an account is the `owner` or has a specific role
      */
     modifier onlyOwnerOrRole(bytes32 role) {
-        if (msg.sender != owner() || !hasRole(role, msg.sender))
+        if (msg.sender != owner() && !hasRole(role, msg.sender))
             revert SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner(
                 role,
                 msg.sender

--- a/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
+++ b/contracts/utils/SafeAccessControlEnumerableUpgradeable.sol
@@ -40,6 +40,8 @@ abstract contract SafeAccessControlEnumerableUpgradeable is
 
     function __SafeAccessControlEnumerable_init() internal onlyInitializing {
         __PendingOwnable_init();
+        __AccessControlEnumerable_init();
+
         __SafeAccessControlEnumerable_init_unchained();
     }
 

--- a/contracts/utils/SafePausable.sol
+++ b/contracts/utils/SafePausable.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "./SafeAccessControlEnumerable.sol";

--- a/contracts/utils/SafePausable.sol
+++ b/contracts/utils/SafePausable.sol
@@ -11,7 +11,11 @@ import "../interfaces/ISafePausable.sol";
 error SafePausable__AlreadyPaused();
 error SafePausable__AlreadyUnpaused();
 
-abstract contract SafePausable is SafeAccessControlEnumerable, ISafePausable {
+abstract contract SafePausable is
+    SafeAccessControlEnumerable,
+    Pausable,
+    ISafePausable
+{
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER_ROLE");
 

--- a/contracts/utils/SafePausable.sol
+++ b/contracts/utils/SafePausable.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+
+import "./SafeAccessControlEnumerable.sol";
+import "../interfaces/ISafePausable.sol";
+
+error SafePausable__AlreadyPaused();
+error SafePausable__AlreadyUnpaused();
+
+abstract contract SafePausable is SafeAccessControlEnumerable, ISafePausable {
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER_ROLE");
+
+    bytes32 public constant PAUSER_ADMIN_ROLE = keccak256("PAUSER_ADMIN_ROLE");
+    bytes32 public constant UNPAUSER_ADMIN_ROLE =
+        keccak256("UNPAUSER_ADMIN_ROLE");
+
+    /**
+     * @dev Set the role admins
+     */
+    constructor() {
+        _setRoleAdmin(PAUSER_ROLE, PAUSER_ADMIN_ROLE);
+        _setRoleAdmin(UNPAUSER_ROLE, UNPAUSER_ADMIN_ROLE);
+    }
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SafeAccessControlEnumerable)
+        returns (bool)
+    {
+        return
+            interfaceId == type(ISafePausable).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice Pauses the contract.
+     * @dev Sensible part of a contract might be pausable for security reasons.
+     *
+     * Requirements:
+     * - the caller must be the `owner` or have the ``role`` role.
+     * - the contrat needs to be unpaused.
+     */
+    function pause() public virtual override onlyOwnerOrRole(PAUSER_ROLE) {
+        if (paused()) revert SafePausable__AlreadyPaused();
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses the contract.
+     * @dev Sensible part of a contract might be pausable for security reasons.
+     *
+     * Requirements:
+     * - the caller must be the `owner` or have the ``role`` role.
+     * - the contrat needs to be unpaused.
+     */
+    function unpause() public virtual override onlyOwnerOrRole(UNPAUSER_ROLE) {
+        if (!paused()) revert SafePausable__AlreadyUnpaused();
+        _unpause();
+    }
+}

--- a/contracts/utils/SafePausableUpgradeable.sol
+++ b/contracts/utils/SafePausableUpgradeable.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+import "./SafeAccessControlEnumerableUpgradeable.sol";
+import "../interfaces/ISafePausableUpgradeable.sol";
+
+error SafePausableUpgradeable__AlreadyPaused();
+error SafePausableUpgradeable__AlreadyUnpaused();
+
+abstract contract SafePausableUpgradeable is
+    SafeAccessControlEnumerableUpgradeable,
+    PausableUpgradeable,
+    ISafePausableUpgradeable
+{
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER_ROLE");
+
+    bytes32 public constant PAUSER_ADMIN_ROLE = keccak256("PAUSER_ADMIN_ROLE");
+    bytes32 public constant UNPAUSER_ADMIN_ROLE =
+        keccak256("UNPAUSER_ADMIN_ROLE");
+
+    function __SafePausable_init() internal onlyInitializing {
+        __SafeAccessControlEnumerable_init();
+        __Pausable_init();
+
+        __SafePausable_init_unchained();
+    }
+
+    function __SafePausable_init_unchained() internal onlyInitializing {
+        _setRoleAdmin(PAUSER_ROLE, PAUSER_ADMIN_ROLE);
+        _setRoleAdmin(UNPAUSER_ROLE, UNPAUSER_ADMIN_ROLE);
+    }
+
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SafeAccessControlEnumerableUpgradeable)
+        returns (bool)
+    {
+        return
+            interfaceId == type(ISafePausableUpgradeable).interfaceId ||
+            SafeAccessControlEnumerableUpgradeable.supportsInterface(
+                interfaceId
+            );
+    }
+
+    /**
+     * @notice Pauses the contract.
+     * @dev Sensible part of a contract might be pausable for security reasons.
+     *
+     * Requirements:
+     * - the caller must be the `owner` or have the ``role`` role.
+     * - the contrat needs to be unpaused.
+     */
+    function pause() public virtual override onlyOwnerOrRole(PAUSER_ROLE) {
+        if (paused()) revert SafePausableUpgradeable__AlreadyPaused();
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses the contract.
+     * @dev Sensible part of a contract might be pausable for security reasons.
+     *
+     * Requirements:
+     * - the caller must be the `owner` or have the ``role`` role.
+     * - the contrat needs to be unpaused.
+     */
+    function unpause() public virtual override onlyOwnerOrRole(UNPAUSER_ROLE) {
+        if (!paused()) revert SafePausableUpgradeable__AlreadyUnpaused();
+        _unpause();
+    }
+}

--- a/test/SafeAccessControlEnumerable.test.js
+++ b/test/SafeAccessControlEnumerable.test.js
@@ -1,0 +1,229 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+const DEFAULT_ADMIN =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
+const A_ADMIN_ROLE = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes("A_ADMIN_ROLE")
+);
+const A_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("A_ROLE"));
+const B_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("B_ROLE"));
+
+describe("SafeAccessControlEnumerable", function () {
+  before(async function () {
+    this.safeAccessControlEnumerableCF = await ethers.getContractFactory(
+      "MockSafeAccessControlEnumerable"
+    );
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.safeAccess = await this.safeAccessControlEnumerableCF.deploy();
+  });
+
+  it("Should allow owner to grant role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess.grantRole(A_ROLE, this.bob.address);
+    await this.safeAccess.grantRole(B_ROLE, this.bob.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(true);
+    expect(
+      await this.safeAccess.hasRole(B_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+    expect(await this.safeAccess.hasRole(B_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+  });
+
+  it("Should allow owner to revoke role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess.grantRole(A_ROLE, this.bob.address);
+    await this.safeAccess.grantRole(B_ROLE, this.bob.address);
+
+    await this.safeAccess.revokeRole(A_ROLE, this.alice.address);
+    await this.safeAccess.revokeRole(B_ROLE, this.bob.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(
+      await this.safeAccess.hasRole(B_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+    expect(await this.safeAccess.hasRole(B_ROLE, this.bob.address)).to.be.equal(
+      false
+    );
+  });
+
+  it("Should allow user to revoke role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess
+      .connect(this.alice)
+      .renounceRole(A_ROLE, this.alice.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(false);
+  });
+
+  it("Should transfer DEFAULT_ADMIN to new owner", async function () {
+    expect(await this.safeAccess.owner()).to.be.equal(this.dev.address);
+
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.equal(true);
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.equal(false);
+
+    await this.safeAccess.connect(this.dev).setPendingOwner(this.alice.address);
+    await this.safeAccess.connect(this.alice).becomeOwner();
+
+    expect(await this.safeAccess.owner()).to.be.equal(this.alice.address);
+
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.equal(false);
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.equal(true);
+  });
+
+  it("Should allow to renounce ownership", async function () {
+    expect(await this.safeAccess.owner()).to.be.equal(this.dev.address);
+    await this.safeAccess.renounceOwnership();
+
+    expect(await this.safeAccess.owner()).to.be.equal(
+      ethers.constants.AddressZero
+    );
+
+    expect(await this.safeAccess.getRoleMemberCount(DEFAULT_ADMIN)).to.be.equal(
+      0
+    );
+  });
+
+  it("Should allow role admin to grant role", async function () {
+    await this.safeAccess.setRoleAdmin(A_ROLE, A_ADMIN_ROLE);
+
+    expect(await this.safeAccess.getRoleAdmin(A_ROLE)).to.be.equal(
+      A_ADMIN_ROLE
+    );
+
+    await this.safeAccess.grantRole(A_ADMIN_ROLE, this.alice.address);
+
+    await this.safeAccess
+      .connect(this.alice)
+      .grantRole(A_ROLE, this.bob.address);
+
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+
+    await expect(
+      this.safeAccess.connect(this.bob).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await this.safeAccess
+      .connect(this.alice)
+      .revokeRole(A_ROLE, this.bob.address);
+
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      false
+    );
+
+    await this.safeAccess.setRoleAdmin(A_ROLE, DEFAULT_ADMIN);
+
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if a non owner tries to grant or revoke the contract", async function () {
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await expect(
+      this.safeAccess.connect(this.alice).revokeRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safeAccess.connect(this.alice).revokeRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await expect(
+      this.safeAccess.connect(this.alice).renounceRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith("AccessControl: can only renounce roles for self");
+  });
+
+  it("Should revert if trying to revert or grant DEFAULT_ADMIN", async function () {
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .grantRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .grantRole(DEFAULT_ADMIN, this.bob.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .revokeRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .revokeRole(DEFAULT_ADMIN, this.bob.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .renounceRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .renounceRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.revertedWith("SafeAccessControlEnumerable__RoleIsDefaultAdmin");
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});

--- a/test/SafeAccessControlEnumerableUpgradeable.test.js
+++ b/test/SafeAccessControlEnumerableUpgradeable.test.js
@@ -1,0 +1,248 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+const DEFAULT_ADMIN =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
+const A_ADMIN_ROLE = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes("A_ADMIN_ROLE")
+);
+const A_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("A_ROLE"));
+const B_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("B_ROLE"));
+
+describe("SafeAccessControlEnumerableUpgradeable", function () {
+  before(async function () {
+    this.safeAccessControlEnumerableCF = await ethers.getContractFactory(
+      "MockSafeAccessControlEnumerableUpgradeable"
+    );
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.safeAccess = await this.safeAccessControlEnumerableCF.deploy();
+    await this.safeAccess.initialize();
+  });
+
+  it("Should allow owner to grant role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess.grantRole(A_ROLE, this.bob.address);
+    await this.safeAccess.grantRole(B_ROLE, this.bob.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(true);
+    expect(
+      await this.safeAccess.hasRole(B_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+    expect(await this.safeAccess.hasRole(B_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+  });
+
+  it("Should allow owner to revoke role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess.grantRole(A_ROLE, this.bob.address);
+    await this.safeAccess.grantRole(B_ROLE, this.bob.address);
+
+    await this.safeAccess.revokeRole(A_ROLE, this.alice.address);
+    await this.safeAccess.revokeRole(B_ROLE, this.bob.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(
+      await this.safeAccess.hasRole(B_ROLE, this.alice.address)
+    ).to.be.equal(false);
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+    expect(await this.safeAccess.hasRole(B_ROLE, this.bob.address)).to.be.equal(
+      false
+    );
+  });
+
+  it("Should allow user to revoke role", async function () {
+    await this.safeAccess.grantRole(A_ROLE, this.alice.address);
+
+    await this.safeAccess
+      .connect(this.alice)
+      .renounceRole(A_ROLE, this.alice.address);
+
+    expect(
+      await this.safeAccess.hasRole(A_ROLE, this.alice.address)
+    ).to.be.equal(false);
+  });
+
+  it("Should transfer DEFAULT_ADMIN to new owner", async function () {
+    expect(await this.safeAccess.owner()).to.be.equal(this.dev.address);
+
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.equal(true);
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.equal(false);
+
+    await this.safeAccess.connect(this.dev).setPendingOwner(this.alice.address);
+    await this.safeAccess.connect(this.alice).becomeOwner();
+
+    expect(await this.safeAccess.owner()).to.be.equal(this.alice.address);
+
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.equal(false);
+    expect(
+      await this.safeAccess.hasRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.equal(true);
+  });
+
+  it("Should allow to renounce ownership", async function () {
+    expect(await this.safeAccess.owner()).to.be.equal(this.dev.address);
+    await this.safeAccess.renounceOwnership();
+
+    expect(await this.safeAccess.owner()).to.be.equal(
+      ethers.constants.AddressZero
+    );
+
+    expect(await this.safeAccess.getRoleMemberCount(DEFAULT_ADMIN)).to.be.equal(
+      0
+    );
+  });
+
+  it("Should allow role admin to grant role", async function () {
+    await this.safeAccess.setRoleAdmin(A_ROLE, A_ADMIN_ROLE);
+
+    expect(await this.safeAccess.getRoleAdmin(A_ROLE)).to.be.equal(
+      A_ADMIN_ROLE
+    );
+
+    await this.safeAccess.grantRole(A_ADMIN_ROLE, this.alice.address);
+
+    await this.safeAccess
+      .connect(this.alice)
+      .grantRole(A_ROLE, this.bob.address);
+
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      true
+    );
+
+    await expect(
+      this.safeAccess.connect(this.bob).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await this.safeAccess
+      .connect(this.alice)
+      .revokeRole(A_ROLE, this.bob.address);
+
+    expect(await this.safeAccess.hasRole(A_ROLE, this.bob.address)).to.be.equal(
+      false
+    );
+
+    await this.safeAccess.setRoleAdmin(A_ROLE, DEFAULT_ADMIN);
+
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if a non owner tries to grant or revoke the contract", async function () {
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safeAccess.connect(this.alice).grantRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await expect(
+      this.safeAccess.connect(this.alice).revokeRole(A_ROLE, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safeAccess.connect(this.alice).revokeRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+
+    await expect(
+      this.safeAccess.connect(this.alice).renounceRole(A_ROLE, this.bob.address)
+    ).to.be.revertedWith("AccessControl: can only renounce roles for self");
+  });
+
+  it("Should revert if trying to revert or grant DEFAULT_ADMIN", async function () {
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .grantRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .grantRole(DEFAULT_ADMIN, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .revokeRole(DEFAULT_ADMIN, this.alice.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .revokeRole(DEFAULT_ADMIN, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+
+    await expect(
+      this.safeAccess
+        .connect(this.alice)
+        .renounceRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+    await expect(
+      this.safeAccess
+        .connect(this.dev)
+        .renounceRole(DEFAULT_ADMIN, this.dev.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__RoleIsDefaultAdmin"
+    );
+  });
+
+  it("Should revert if trying to initialize again", async function () {
+    await expect(this.safeAccess.initialize()).to.be.revertedWith(
+      "Initializable: contract is already initialized"
+    );
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});

--- a/test/SafePausable.test.js
+++ b/test/SafePausable.test.js
@@ -1,0 +1,171 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+let PAUSER_ROLE, UNPAUSER_ROLE, PAUSER_ADMIN_ROLE, UNPAUSER_ADMIN_ROLE;
+describe("SafePausable", function () {
+  before(async function () {
+    this.safePausableCF = await ethers.getContractFactory("MockSafePausable");
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.safePausable = await this.safePausableCF.deploy();
+
+    PAUSER_ROLE = await this.safePausable.PAUSER_ROLE();
+    UNPAUSER_ROLE = await this.safePausable.UNPAUSER_ROLE();
+
+    PAUSER_ADMIN_ROLE = await this.safePausable.PAUSER_ADMIN_ROLE();
+    UNPAUSER_ADMIN_ROLE = await this.safePausable.UNPAUSER_ADMIN_ROLE();
+  });
+
+  it("Should allow owner to pause and unpause", async function () {
+    await this.safePausable.pause();
+    await expect(this.safePausable.pause()).to.be.revertedWith(
+      "SafePausable__AlreadyPaused"
+    );
+
+    await expect(this.safePausable.pausableFunction()).to.be.revertedWith(
+      "Pausable: paused"
+    );
+    await this.safePausable.doSomething();
+
+    await this.safePausable.unpause();
+    await expect(this.safePausable.unpause()).to.be.revertedWith(
+      "SafePausable__AlreadyUnpaused"
+    );
+
+    await this.safePausable.pausableFunction();
+    await this.safePausable.doSomething();
+  });
+
+  it("Should allow PAUSE_ROLE to pause", async function () {
+    await this.safePausable.grantRole(PAUSER_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.bob).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await this.safePausable.connect(this.alice).pause();
+
+    await expect(this.safePausable.pausableFunction()).to.be.revertedWith(
+      "Pausable: paused"
+    );
+  });
+
+  it("Should allow UNPAUSE_ROLE to unpause", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ROLE, this.alice.address);
+    await this.safePausable.pause();
+
+    await expect(
+      this.safePausable.connect(this.bob).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await this.safePausable.connect(this.alice).unpause();
+
+    await this.safePausable.pausableFunction();
+  });
+
+  it("Should allow PAUSER_ADMIN_ROLE to only grant PAUSER_ROLE", async function () {
+    await this.safePausable.grantRole(PAUSER_ADMIN_ROLE, this.alice.address);
+
+    await this.safePausable
+      .connect(this.alice)
+      .grantRole(PAUSER_ROLE, this.bob.address);
+
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should allow UNPAUSER_ADMIN_ROLE to only grant UNPAUSER_ROLE", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ADMIN_ROLE, this.alice.address);
+
+    await this.safePausable
+      .connect(this.alice)
+      .grantRole(UNPAUSER_ROLE, this.bob.address);
+
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if PAUSER_ADMIN_ROLE tries to pause/unpause", async function () {
+    await this.safePausable.grantRole(PAUSER_ADMIN_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.alice).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable.connect(this.alice).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if UNPAUSER_ADMIN_ROLE tries to pause/unpause", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ADMIN_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.alice).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable.connect(this.alice).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});

--- a/test/SafePausableUpgradeable.test.js
+++ b/test/SafePausableUpgradeable.test.js
@@ -1,0 +1,180 @@
+const { config, ethers, network } = require("hardhat");
+const { expect } = require("chai");
+
+let PAUSER_ROLE, UNPAUSER_ROLE, PAUSER_ADMIN_ROLE, UNPAUSER_ADMIN_ROLE;
+describe.only("SafePausableUpgradeable", function () {
+  before(async function () {
+    this.safePausableCF = await ethers.getContractFactory(
+      "MockSafePausableUpgradeable"
+    );
+
+    this.signers = await ethers.getSigners();
+    this.dev = this.signers[0];
+    this.alice = this.signers[1];
+    this.bob = this.signers[2];
+    this.exploiter = this.signers[2];
+  });
+
+  beforeEach(async function () {
+    this.safePausable = await this.safePausableCF.deploy();
+    await this.safePausable.initialize();
+
+    PAUSER_ROLE = await this.safePausable.PAUSER_ROLE();
+    UNPAUSER_ROLE = await this.safePausable.UNPAUSER_ROLE();
+
+    PAUSER_ADMIN_ROLE = await this.safePausable.PAUSER_ADMIN_ROLE();
+    UNPAUSER_ADMIN_ROLE = await this.safePausable.UNPAUSER_ADMIN_ROLE();
+  });
+
+  it("Should allow owner to pause and unpause", async function () {
+    await this.safePausable.pause();
+    await expect(this.safePausable.pause()).to.be.revertedWith(
+      "SafePausableUpgradeable__AlreadyPaused"
+    );
+
+    await expect(this.safePausable.pausableFunction()).to.be.revertedWith(
+      "Pausable: paused"
+    );
+    await this.safePausable.doSomething();
+
+    await this.safePausable.unpause();
+    await expect(this.safePausable.unpause()).to.be.revertedWith(
+      "SafePausableUpgradeable__AlreadyUnpaused"
+    );
+
+    await this.safePausable.pausableFunction();
+    await this.safePausable.doSomething();
+  });
+
+  it("Should allow PAUSE_ROLE to pause", async function () {
+    await this.safePausable.grantRole(PAUSER_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.bob).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await this.safePausable.connect(this.alice).pause();
+
+    await expect(this.safePausable.pausableFunction()).to.be.revertedWith(
+      "Pausable: paused"
+    );
+  });
+
+  it("Should allow UNPAUSE_ROLE to unpause", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ROLE, this.alice.address);
+    await this.safePausable.pause();
+
+    await expect(
+      this.safePausable.connect(this.bob).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await this.safePausable.connect(this.alice).unpause();
+
+    await this.safePausable.pausableFunction();
+  });
+
+  it("Should allow PAUSER_ADMIN_ROLE to only grant PAUSER_ROLE", async function () {
+    await this.safePausable.grantRole(PAUSER_ADMIN_ROLE, this.alice.address);
+
+    await this.safePausable
+      .connect(this.alice)
+      .grantRole(PAUSER_ROLE, this.bob.address);
+
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should allow UNPAUSER_ADMIN_ROLE to only grant UNPAUSER_ROLE", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ADMIN_ROLE, this.alice.address);
+
+    await this.safePausable
+      .connect(this.alice)
+      .grantRole(UNPAUSER_ROLE, this.bob.address);
+
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(PAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable
+        .connect(this.alice)
+        .grantRole(UNPAUSER_ADMIN_ROLE, this.bob.address)
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if PAUSER_ADMIN_ROLE tries to pause/unpause", async function () {
+    await this.safePausable.grantRole(PAUSER_ADMIN_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.alice).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable.connect(this.alice).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if UNPAUSER_ADMIN_ROLE tries to pause/unpause", async function () {
+    await this.safePausable.grantRole(UNPAUSER_ADMIN_ROLE, this.alice.address);
+
+    await expect(
+      this.safePausable.connect(this.alice).pause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+    await expect(
+      this.safePausable.connect(this.alice).unpause()
+    ).to.be.revertedWith(
+      "SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner"
+    );
+  });
+
+  it("Should revert if trying to initialize again", async function () {
+    await expect(this.safePausable.initialize()).to.be.revertedWith(
+      "Initializable: contract is already initialized"
+    );
+  });
+
+  after(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+});


### PR DESCRIPTION
The goal of this PR is to remove the `PausableAdmin` contract entirely and use this one as it resolves some issues (mainly when the owner revokes) and allows for more things.

The contract can be renounced, but the pausable/unpausable admin would still be able to add/remove pausers/unpausers.

For contracts that need more than just a pause function, the `SafeAccessControlEnumerable` can be inherited the same way it's done within `SafePausable`.

Also, there is some cleaning / tiny fix for other contracts.